### PR TITLE
Changed SkedlerUser to be string not password

### DIFF
--- a/templates/v3-aws/0/rancher-compose.yml
+++ b/templates/v3-aws/0/rancher-compose.yml
@@ -166,7 +166,7 @@ version: '2'
       default: "s13M0nSterV3"
 
     - variable: "SKEDLER_USER"
-      type: "password"
+      type: "string"
       required: true
       label: "Skedler Username"
       description: "Set the Skedler Username for Elasticsearch connnection"


### PR DESCRIPTION
Having the Skedler username field as a password causes the generate password button to be available which I suspect is breaking some ES installs